### PR TITLE
Fix handling CORBA server-to-client close connection messages

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,7 @@
 module.exports = {
 	globals: {
 		'ts-jest': {
-			tsConfig: 'tsconfig.jest.json',
+			tsconfig: 'tsconfig.jest.json',
 			diagnostics: false
 		}
 	},

--- a/src/__tests__/spawn_server.ts
+++ b/src/__tests__/spawn_server.ts
@@ -75,8 +75,10 @@ export async function start (): Promise<string> {
 export async function stop (): Promise<void> {
 	return new Promise<void>((resolve) => {
 		if (mockServer) {
-			mockServer.kill()
+			console.log('Sending close!')
+			mockServer.send('close')
 			mockServer.on('exit', (_code, _signal) => {
+				console.log('Exiting!')
 				if (app) {
 					app.close(() => {
 						resolve()

--- a/src/__tests__/test_framework.test.ts
+++ b/src/__tests__/test_framework.test.ts
@@ -25,6 +25,12 @@ import { app } from '../server'
 import { Server } from 'http'
 import * as request from 'request-promise-native'
 
+// const wait = (t: number): Promise<void> => { 
+// 	return new Promise((resolve) => {
+// 		setTimeout(resolve, t)
+// 	})
+// }
+
 describe('Test framework', () => {
 
 	let isaIOR: string
@@ -128,7 +134,7 @@ describe('Error handling when no server running', () => {
 
 	test('Test failed IOR HTTP connection', async () => {
 		expect.assertions(1)
-		await expect(Quantel.getServers()).rejects.toThrow('CORBA subsystem: TRANSIENT')
+		await expect(Quantel.getServers()).rejects.toThrow('TIMEOUT')
 	})
 
 	test('Test fail to get servers 1', async () => {
@@ -160,7 +166,12 @@ describe('Error handling when server has failed', () => {
 
 	test('Test fail to get servers 1', async () => {
 		expect.assertions(1)
-		await expect(Quantel.getServers()).rejects.toThrow('CORBA subsystem: TRANSIENT')
+		await expect(Quantel.getServers()).rejects.toThrow('TIMEOUT')
+	})
+
+	test('Test fail to get servers 2', async () => {
+		expect.assertions(1)
+		await expect(Quantel.getServers()).rejects.toThrow('ECONNREFUSED')
 	})
 
 	test('Test the failed CORBA connection', async () => {
@@ -214,7 +225,7 @@ describe('Error handling when server has failed, two servers', () => {
 
 	test('Test fail to get servers 1', async () => {
 		expect.assertions(1)
-		await expect(Quantel.getServers()).rejects.toThrow('CORBA subsystem: TRANSIENT')
+		await expect(Quantel.getServers()).rejects.toThrow('TIMEOUT')
 	})
 
 	test('Test the failed CORBA connection 1', async () => {
@@ -273,8 +284,8 @@ describe('Check overlapping requests on failure', () => {
 	test('Test fail to get servers 1', async () => {
 		expect.assertions(2)
 		await Promise.all([
-			expect(Quantel.getServers()).rejects.toThrow('CORBA subsystem: TRANSIENT'),
-			expect(Quantel.getServers()).rejects.toThrow('CORBA subsystem: TRANSIENT') ])
+			expect(Quantel.getServers()).rejects.toThrow('TIMEOUT'),
+			expect(Quantel.getServers()).rejects.toThrow('TIMEOUT') ])
 	})
 
 	test('Test the failed CORBA connection 1', async () => {

--- a/src/__tests__/test_framework.test.ts
+++ b/src/__tests__/test_framework.test.ts
@@ -25,7 +25,7 @@ import { app } from '../server'
 import { Server } from 'http'
 import * as request from 'request-promise-native'
 
-// const wait = (t: number): Promise<void> => { 
+// const wait = (t: number): Promise<void> => {
 // 	return new Promise((resolve) => {
 // 		setTimeout(resolve, t)
 // 	})

--- a/src/__tests__/test_server.js
+++ b/src/__tests__/test_server.js
@@ -40,11 +40,11 @@ const loopy = setInterval(() => {
 }, 10);
 
 const closeDown = () => {
-	console.error("closeDown called");
+	// console.error("closeDown called");
 	clearInterval(loopy);
-	console.log('quantel.closeServer about to call');
+	// console.log('quantel.closeServer about to call');
 	quantel.closeServer();
-	console.log('quantel.closeServer returned');
+	// console.log('quantel.closeServer returned');
 	// quantel.performWork();
 	// quantel.deactivatePman();
 	setTimeout(() => { process.exit(); }, 3000);
@@ -57,7 +57,7 @@ process.on('message', m => {
 	}
 })
 
-process.on('exit', () => {
-	console.log('BANG!!!')
-})
+// process.on('exit', () => {
+// 	console.log('BANG!!!')
+// })
 

--- a/src/__tests__/test_server.js
+++ b/src/__tests__/test_server.js
@@ -24,4 +24,40 @@ const quantel = require('../../build/Release/quantel_gateway')
 // const SegfaultHandler = require('segfault-handler')
 // SegfaultHandler.registerHandler('crash2.log')
 
+
+
+// process.on('SIGHUP', () => {
+// 	quantel.closeServer()
+// 	console.log("Close server called.")
+// 	setTimeout(() => {}, 3000)
+// })
+
 quantel.runServer()
+
+const loopy = setInterval(() => {
+	// console.log('loopy');
+	quantel.performWork();
+}, 10);
+
+const closeDown = () => {
+	console.error("closeDown called");
+	clearInterval(loopy);
+	console.log('quantel.closeServer about to call');
+	quantel.closeServer();
+	console.log('quantel.closeServer returned');
+	// quantel.performWork();
+	// quantel.deactivatePman();
+	setTimeout(() => { process.exit(); }, 3000);
+}
+
+process.on('SIGINT', closeDown)
+process.on('message', m => {
+	if (typeof m === 'string' && m === 'close') {
+		closeDown();
+	}
+})
+
+process.on('exit', () => {
+	console.log('BANG!!!')
+})
+

--- a/src/cxx/qgw_util.cc
+++ b/src/cxx/qgw_util.cc
@@ -108,7 +108,10 @@ napi_status retrieveZonePortalShared(napi_env env, napi_callback_info info, CORB
   PASS_STATUS;
 
   if (local_orb == nullptr) {
-		const char* options[][2] = { { "traceLevel", "1" }, { 0, 0 } };
+		const char* options[][2] = { 
+			{ "traceLevel", "1" },
+			{ 0, 0 } 
+		};
 		int orbc = 0;
 		local_orb = CORBA::ORB_init(orbc, nullptr, "omniORB4", options);
 	}
@@ -137,7 +140,12 @@ Quentin::ZonePortal_ptr local_zp = nullptr;
 
 napi_status resolveZonePortalShared(char* ior, Quentin::ZonePortal_ptr *zp) {
 	if (local_orb == nullptr) {
-		const char* options[][2] = { { "traceLevel", "21" }, { 0, 0 } };
+		const char* options[][2] = { 
+			{ "traceLevel", "1" }, 
+			{ "clientCallTimeOutPeriod", "2000" },
+			{ "clientConnectTimeOutPeriod", "2000" }, 
+			{ 0, 0 } 
+		};
 	  int orbc = 0;
 	  local_orb = CORBA::ORB_init(orbc, nullptr, "omniORB4", options);
 	}

--- a/src/cxx/qgw_util.cc
+++ b/src/cxx/qgw_util.cc
@@ -137,7 +137,7 @@ Quentin::ZonePortal_ptr local_zp = nullptr;
 
 napi_status resolveZonePortalShared(char* ior, Quentin::ZonePortal_ptr *zp) {
 	if (local_orb == nullptr) {
-		const char* options[][2] = { { "traceLevel", "1" }, { 0, 0 } };
+		const char* options[][2] = { { "traceLevel", "21" }, { 0, 0 } };
 	  int orbc = 0;
 	  local_orb = CORBA::ORB_init(orbc, nullptr, "omniORB4", options);
 	}

--- a/src/cxx/quantel_gateway.cc
+++ b/src/cxx/quantel_gateway.cc
@@ -27,6 +27,7 @@
 #include "clone.h"
 #include "thumbs.h"
 #include "test_server.h"
+#include <omniORB4/omniORB.h>
 
 napi_value timecodeFromBCD(napi_env env, napi_callback_info info) {
 	napi_status status;
@@ -73,6 +74,12 @@ napi_value timecodeToBCD(napi_env env, napi_callback_info info) {
 	CHECK_STATUS;
 
 	return result;
+}
+
+CORBA::Boolean commFailureHandler (void* cookie, CORBA::ULong retries, const CORBA::COMM_FAILURE& ex)
+{
+   printf("comm failure handler called.\n");
+   return 0;
 }
 
 napi_value Init(napi_env env, napi_value exports) {
@@ -132,6 +139,8 @@ napi_value Init(napi_env env, napi_value exports) {
   };
   status = napi_define_properties(env, exports, 37, desc);
 	CHECK_STATUS;
+
+  omniORB::installCommFailureExceptionHandler(0, commFailureHandler);
 
   return exports;
 }

--- a/src/cxx/quantel_gateway.cc
+++ b/src/cxx/quantel_gateway.cc
@@ -119,6 +119,9 @@ napi_value Init(napi_env env, napi_value exports) {
 		DECLARE_NAPI_METHOD("getCopyRemaining", getCopyRemaining),
 		DECLARE_NAPI_METHOD("getCopiesRemaining", getCopiesRemaining),
 		DECLARE_NAPI_METHOD("runServer", runServer),
+		DECLARE_NAPI_METHOD("closeServer", closeServer),
+		DECLARE_NAPI_METHOD("performWork", performWork),
+		DECLARE_NAPI_METHOD("deactivatePman", deactivatePman), 
 		DECLARE_NAPI_METHOD("destroyOrb", destroyOrb),
     { "START", nullptr, nullptr, nullptr, nullptr, start, napi_enumerable, nullptr },
     { "STOP", nullptr, nullptr, nullptr, nullptr, stop, napi_enumerable, nullptr }, // 30
@@ -127,7 +130,7 @@ napi_value Init(napi_env env, napi_value exports) {
 		{ "STANDARD", nullptr, nullptr, nullptr, nullptr, standard, napi_enumerable, nullptr},
 		{ "HIGH", nullptr, nullptr, nullptr, nullptr, high, napi_enumerable, nullptr},
   };
-  status = napi_define_properties(env, exports, 34, desc);
+  status = napi_define_properties(env, exports, 37, desc);
 	CHECK_STATUS;
 
   return exports;

--- a/src/cxx/test_server.cc
+++ b/src/cxx/test_server.cc
@@ -786,7 +786,7 @@ napi_value runServer(napi_env env, napi_callback_info info) {
 	// napi_status status;
 
 	int argc = 0;
-	const char* options[][2] = { { "traceLevel", "21" }, { 0, 0 } };
+	const char* options[][2] = { { "traceLevel", "1" }, { 0, 0 } };
 	CORBA::ORB_var orb = CORBA::ORB_init(argc, nullptr,"omniORB4",options);
 	myPrettyOrb = orb;
   	CORBA::Object_var obj = orb->resolve_initial_references("RootPOA");
@@ -814,7 +814,7 @@ napi_value runServer(napi_env env, napi_callback_info info) {
 }
 
 napi_value closeServer(napi_env env, napi_callback_info info) {
-	printf("closeServer called.\n");
+	// printf("closeServer called.\n");
 	if (closeMe != nullptr) {
 		myYummyPoa->deactivate_object(myZpId);
 	}

--- a/src/cxx/test_server.h
+++ b/src/cxx/test_server.h
@@ -27,5 +27,8 @@
 #include <wchar.h>
 
 napi_value runServer(napi_env env, napi_callback_info info);
+napi_value closeServer(napi_env env, napi_callback_info info);
+napi_value performWork(napi_env env, napi_callback_info info);
+napi_value deactivatePman(napi_env env, napi_callback_info info);
 
 #endif // QGW_TEST_SERVER

--- a/src/index.ts
+++ b/src/index.ts
@@ -479,8 +479,11 @@ export namespace Quantel {
 			return await quantel.testConnection(await isaIOR)
 		} catch (err) {
 			// if (err.message.indexOf('TRANSIENT') >= 0) { resetConnection() }
-			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0 ||
-					err.message.indexOf('TRANSIENT') >= 0) {
+			if (
+				err.message.indexOf('OBJECT_NOT_EXIST') >= 0 ||
+				err.message.indexOf('TRANSIENT') >= 0 ||
+				err.message.indexOf('TIMEOUT') >= 0
+			) {
 				resetConnection()
 				return testConnection()
 			}
@@ -493,7 +496,10 @@ export namespace Quantel {
 			await getISAReference()
 			return await quantel.listZones(await isaIOR)
 		} catch (err) {
-			if (err.message.indexOf('TRANSIENT') >= 0) { resetConnection() }
+			if (
+				err.message.indexOf('TRANSIENT') >= 0 ||
+				err.message.indexOf('TIMEOUT') >= 0
+			)  { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
 				resetConnection()
 				return listZones()
@@ -508,7 +514,10 @@ export namespace Quantel {
 			let zones = await quantel.listZones(await isaIOR)
 			return zones[0]
 		} catch (err) {
-			if (err.message.indexOf('TRANSIENT') >= 0) { resetConnection() }
+			if (
+				err.message.indexOf('TRANSIENT') >= 0 ||
+				err.message.indexOf('TIMEOUT') >= 0
+			)  { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
 				resetConnection()
 				return getDefaultZoneInfo()
@@ -522,7 +531,10 @@ export namespace Quantel {
 			await getISAReference()
 			return await quantel.getServers(await isaIOR)
 		} catch (err) {
-			if (err.message.indexOf('TRANSIENT') >= 0) { resetConnection() }
+			if (
+				err.message.indexOf('TRANSIENT') >= 0 ||
+				err.message.indexOf('TIMEOUT') >= 0
+			)  { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
 				resetConnection()
 				return getServers()
@@ -536,7 +548,10 @@ export namespace Quantel {
 			await getISAReference()
 			return await quantel.getFormatInfo(await isaIOR, options)
 		} catch (err) {
-			if (err.message.indexOf('TRANSIENT') >= 0) { resetConnection() }
+			if (
+				err.message.indexOf('TRANSIENT') >= 0 ||
+				err.message.indexOf('TIMEOUT') >= 0
+			)  { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
 				resetConnection()
 				return getFormatInfo(options)
@@ -563,7 +578,10 @@ export namespace Quantel {
 			}
 			return formats
 		} catch (err) {
-			if (err.message.indexOf('TRANSIENT') >= 0) { resetConnection() }
+			if (
+				err.message.indexOf('TRANSIENT') >= 0 ||
+				err.message.indexOf('TIMEOUT') >= 0
+			)  { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
 				resetConnection()
 				return getFormats()
@@ -614,7 +632,10 @@ export namespace Quantel {
 
 			return await quantel.createPlayPort(await isaIOR, options)
 		} catch (err) {
-			if (err.message.indexOf('TRANSIENT') >= 0) { resetConnection() }
+			if (
+				err.message.indexOf('TRANSIENT') >= 0 ||
+				err.message.indexOf('TIMEOUT') >= 0
+			)  { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
 				resetConnection()
 				return createPlayPort(options)
@@ -637,7 +658,10 @@ export namespace Quantel {
 			await checkServerPort(options)
 			return await quantel.getPlayPortStatus(await isaIOR, options)
 		} catch (err) {
-			if (err.message.indexOf('TRANSIENT') >= 0) { resetConnection() }
+			if (
+				err.message.indexOf('TRANSIENT') >= 0 ||
+				err.message.indexOf('TIMEOUT') >= 0
+			)  { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
 				resetConnection()
 				return getPlayPortStatus(options)
@@ -652,7 +676,10 @@ export namespace Quantel {
 			await checkServerPort(options)
 			return await quantel.releasePort(await isaIOR, options)
 		} catch (err) {
-			if (err.message.indexOf('TRANSIENT') >= 0) { resetConnection() }
+			if (
+				err.message.indexOf('TRANSIENT') >= 0 ||
+				err.message.indexOf('TIMEOUT') >= 0
+			)  { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
 				resetConnection()
 				return releasePort(options)
@@ -666,7 +693,10 @@ export namespace Quantel {
 			await getISAReference()
 			return await quantel.getClipData(await isaIOR, options)
 		} catch (err) {
-			if (err.message.indexOf('TRANSIENT') >= 0) { resetConnection() }
+			if (
+				err.message.indexOf('TRANSIENT') >= 0 ||
+				err.message.indexOf('TIMEOUT') >= 0
+			)  { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
 				resetConnection()
 				return getClipData(options)
@@ -680,7 +710,10 @@ export namespace Quantel {
 			await getISAReference()
 			return await quantel.searchClips(await isaIOR, options)
 		} catch (err) {
-			if (err.message.indexOf('TRANSIENT') >= 0) { resetConnection() }
+			if (
+				err.message.indexOf('TRANSIENT') >= 0 ||
+				err.message.indexOf('TIMEOUT') >= 0
+			)  { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
 				resetConnection()
 				return searchClips(options)
@@ -697,7 +730,10 @@ export namespace Quantel {
 			}
 			return await quantel.getFragments(await isaIOR, options)
 		} catch (err) {
-			if (err.message.indexOf('TRANSIENT') >= 0) { resetConnection() }
+			if (
+				err.message.indexOf('TRANSIENT') >= 0 ||
+				err.message.indexOf('TIMEOUT') >= 0
+			)  { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
 				resetConnection()
 				return getFragments(options)
@@ -715,7 +751,10 @@ export namespace Quantel {
 			}
 			return await quantel.loadPlayPort(await isaIOR, options)
 		} catch (err) {
-			if (err.message.indexOf('TRANSIENT') >= 0) { resetConnection() }
+			if (
+				err.message.indexOf('TRANSIENT') >= 0 ||
+				err.message.indexOf('TIMEOUT') >= 0
+			)  { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
 				resetConnection()
 				return loadPlayPort(options)
@@ -730,7 +769,10 @@ export namespace Quantel {
 			await checkServerPort(options)
 			return await quantel.getPortFragments(await isaIOR, options)
 		} catch (err) {
-			if (err.message.indexOf('TRANSIENT') >= 0) { resetConnection() }
+			if (
+				err.message.indexOf('TRANSIENT') >= 0 ||
+				err.message.indexOf('TIMEOUT') >= 0
+			)  { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
 				resetConnection()
 				return getPortFragments(options)
@@ -752,7 +794,10 @@ export namespace Quantel {
 				success: await quantel.trigger(await isaIOR, options)
 			}
 		} catch (err) {
-			if (err.message.indexOf('TRANSIENT') >= 0) { resetConnection() }
+			if (
+				err.message.indexOf('TRANSIENT') >= 0 ||
+				err.message.indexOf('TIMEOUT') >= 0
+			)  { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
 				resetConnection()
 				return trigger(options)
@@ -773,7 +818,10 @@ export namespace Quantel {
 				success: await quantel.jump(await isaIOR, options)
 			}
 		} catch (err) {
-			if (err.message.indexOf('TRANSIENT') >= 0) { resetConnection() }
+			if (
+				err.message.indexOf('TRANSIENT') >= 0 ||
+				err.message.indexOf('TIMEOUT') >= 0
+			)  { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
 				resetConnection()
 				return jump(options)
@@ -794,7 +842,10 @@ export namespace Quantel {
 				success: await quantel.setJump(await isaIOR, options)
 			}
 		} catch (err) {
-			if (err.message.indexOf('TRANSIENT') >= 0) { resetConnection() }
+			if (
+				err.message.indexOf('TRANSIENT') >= 0 ||
+				err.message.indexOf('TIMEOUT') >= 0
+			)  { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
 				resetConnection()
 				return setJump(options)
@@ -808,7 +859,10 @@ export namespace Quantel {
 			await getISAReference()
 			return quantel.getThumbnailSize(await isaIOR)
 		} catch (err) {
-			if (err.message.indexOf('TRANSIENT') >= 0) { resetConnection() }
+			if (
+				err.message.indexOf('TRANSIENT') >= 0 ||
+				err.message.indexOf('TIMEOUT') >= 0
+			)  { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
 				resetConnection()
 				return getThumbnailSize()
@@ -841,7 +895,10 @@ export namespace Quantel {
 			await getISAReference()
 			return await quantel.cloneIfNeeded(await isaIOR, options)
 		} catch (err) {
-			if (err.message.indexOf('TRANSIENT') >= 0) { resetConnection() }
+			if (
+				err.message.indexOf('TRANSIENT') >= 0 ||
+				err.message.indexOf('TIMEOUT') >= 0
+			)  { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
 				resetConnection()
 				return cloneIfNeeded(options)
@@ -855,7 +912,10 @@ export namespace Quantel {
 			await getISAReference()
 			return await quantel.cloneInterZone(await isaIOR, options)
 		} catch (err) {
-			if (err.message.indexOf('TRANSIENT') >= 0) { resetConnection() }
+			if (
+				err.message.indexOf('TRANSIENT') >= 0 ||
+				err.message.indexOf('TIMEOUT') >= 0
+			)  { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
 				resetConnection()
 				return cloneInterZone(options)
@@ -869,7 +929,10 @@ export namespace Quantel {
 			await getISAReference()
 			return await quantel.getCopyRemaining(await isaIOR, options)
 		} catch (err) {
-			if (err.message.indexOf('TRANSIENT') >= 0) { resetConnection() }
+			if (
+				err.message.indexOf('TRANSIENT') >= 0 ||
+				err.message.indexOf('TIMEOUT') >= 0
+			)  { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
 				resetConnection()
 				return getCopyRemaining(options)
@@ -883,7 +946,10 @@ export namespace Quantel {
 			await getISAReference()
 			return await quantel.getCopiesRemaining(await isaIOR)
 		} catch (err) {
-			if (err.message.indexOf('TRANSIENT') >= 0) { resetConnection() }
+			if (
+				err.message.indexOf('TRANSIENT') >= 0 ||
+				err.message.indexOf('TIMEOUT') >= 0
+			)  { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
 				resetConnection()
 				return getCopiesRemaining()
@@ -897,7 +963,10 @@ export namespace Quantel {
 			await getISAReference()
 			return await quantel.deleteClip(await isaIOR, options)
 		} catch (err) {
-			if (err.message.indexOf('TRANSIENT') >= 0) { resetConnection() }
+			if (
+				err.message.indexOf('TRANSIENT') >= 0 ||
+				err.message.indexOf('TIMEOUT') >= 0
+			)  { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
 				resetConnection()
 				return deleteClip(options)
@@ -912,7 +981,10 @@ export namespace Quantel {
 			await checkServerPort(options)
 			return await quantel.wipe(await isaIOR, options)
 		} catch (err) {
-			if (err.message.indexOf('TRANSIENT') >= 0) { resetConnection() }
+			if (
+				err.message.indexOf('TRANSIENT') >= 0 ||
+				err.message.indexOf('TIMEOUT') >= 0
+			)  { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
 				resetConnection()
 				return wipe(options)
@@ -927,7 +999,10 @@ export namespace Quantel {
 			await checkServerPort(options)
 			return await quantel.getPortProperties(await isaIOR, options)
 		} catch (err) {
-			if (err.message.indexOf('TRANSIENT') >= 0) { resetConnection() }
+			if (
+				err.message.indexOf('TRANSIENT') >= 0 ||
+				err.message.indexOf('TIMEOUT') >= 0
+			)  { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
 				resetConnection()
 				return wipe(options)

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,7 @@ export namespace Quantel {
 	let stickyRef: string[] = [ 'http://localhost:2096' ]
 	let robin = 0
 	let connectAttempt = false
+	let objectNotFoundCount = 0
 
 	export interface ZoneInfo {
 		type: 'ZonePortal'
@@ -405,7 +406,12 @@ export namespace Quantel {
 		quantel.destroyOrb()
 	}
 
-	function resetConnection () {
+	function resetConnection (objectNotFound?: boolean) {
+		if (objectNotFound) {
+			objectNotFoundCount++
+		} else {
+			objectNotFoundCount = 0
+		}
 		isaIOR = null
 		robin++
 	}
@@ -415,6 +421,10 @@ export namespace Quantel {
 			throw new ConnectError(`First provide a Quantel ISA connection URL (e.g. POST to /connect).`, 502)
 		} else {
 			connectAttempt = true
+		}
+		if (objectNotFoundCount > 5) {
+			resetConnection(false)
+			throw new ConnectError(`Five OBJECT_NOT_EXIST exceptions in a row. Preventing loop. System in a bad state.`)
 		}
 		if (typeof ref === 'string') ref = [ ref ]
 		let myCount: number = count ? count + 1 : 1
@@ -484,7 +494,7 @@ export namespace Quantel {
 				err.message.indexOf('TRANSIENT') >= 0 ||
 				err.message.indexOf('TIMEOUT') >= 0
 			) {
-				resetConnection()
+				resetConnection(true)
 				return testConnection()
 			}
 			throw err
@@ -499,9 +509,9 @@ export namespace Quantel {
 			if (
 				err.message.indexOf('TRANSIENT') >= 0 ||
 				err.message.indexOf('TIMEOUT') >= 0
-			)  { resetConnection() }
+			) { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
-				resetConnection()
+				resetConnection(true)
 				return listZones()
 			}
 			throw err
@@ -517,9 +527,9 @@ export namespace Quantel {
 			if (
 				err.message.indexOf('TRANSIENT') >= 0 ||
 				err.message.indexOf('TIMEOUT') >= 0
-			)  { resetConnection() }
+			) { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
-				resetConnection()
+				resetConnection(true)
 				return getDefaultZoneInfo()
 			}
 			throw err
@@ -534,9 +544,9 @@ export namespace Quantel {
 			if (
 				err.message.indexOf('TRANSIENT') >= 0 ||
 				err.message.indexOf('TIMEOUT') >= 0
-			)  { resetConnection() }
+			) { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
-				resetConnection()
+				resetConnection(true)
 				return getServers()
 			}
 			throw err
@@ -551,9 +561,9 @@ export namespace Quantel {
 			if (
 				err.message.indexOf('TRANSIENT') >= 0 ||
 				err.message.indexOf('TIMEOUT') >= 0
-			)  { resetConnection() }
+			) { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
-				resetConnection()
+				resetConnection(true)
 				return getFormatInfo(options)
 			}
 			throw err
@@ -581,9 +591,9 @@ export namespace Quantel {
 			if (
 				err.message.indexOf('TRANSIENT') >= 0 ||
 				err.message.indexOf('TIMEOUT') >= 0
-			)  { resetConnection() }
+			) { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
-				resetConnection()
+				resetConnection(true)
 				return getFormats()
 			}
 			throw err
@@ -635,9 +645,9 @@ export namespace Quantel {
 			if (
 				err.message.indexOf('TRANSIENT') >= 0 ||
 				err.message.indexOf('TIMEOUT') >= 0
-			)  { resetConnection() }
+			) { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
-				resetConnection()
+				resetConnection(true)
 				return createPlayPort(options)
 			}
 			throw err
@@ -661,9 +671,9 @@ export namespace Quantel {
 			if (
 				err.message.indexOf('TRANSIENT') >= 0 ||
 				err.message.indexOf('TIMEOUT') >= 0
-			)  { resetConnection() }
+			) { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
-				resetConnection()
+				resetConnection(true)
 				return getPlayPortStatus(options)
 			}
 			throw err
@@ -679,9 +689,9 @@ export namespace Quantel {
 			if (
 				err.message.indexOf('TRANSIENT') >= 0 ||
 				err.message.indexOf('TIMEOUT') >= 0
-			)  { resetConnection() }
+			) { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
-				resetConnection()
+				resetConnection(true)
 				return releasePort(options)
 			}
 			throw err
@@ -696,9 +706,9 @@ export namespace Quantel {
 			if (
 				err.message.indexOf('TRANSIENT') >= 0 ||
 				err.message.indexOf('TIMEOUT') >= 0
-			)  { resetConnection() }
+			) { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
-				resetConnection()
+				resetConnection(true)
 				return getClipData(options)
 			}
 			throw err
@@ -713,9 +723,9 @@ export namespace Quantel {
 			if (
 				err.message.indexOf('TRANSIENT') >= 0 ||
 				err.message.indexOf('TIMEOUT') >= 0
-			)  { resetConnection() }
+			) { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
-				resetConnection()
+				resetConnection(true)
 				return searchClips(options)
 			}
 			throw err
@@ -733,9 +743,9 @@ export namespace Quantel {
 			if (
 				err.message.indexOf('TRANSIENT') >= 0 ||
 				err.message.indexOf('TIMEOUT') >= 0
-			)  { resetConnection() }
+			) { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
-				resetConnection()
+				resetConnection(true)
 				return getFragments(options)
 			}
 			throw err
@@ -754,9 +764,9 @@ export namespace Quantel {
 			if (
 				err.message.indexOf('TRANSIENT') >= 0 ||
 				err.message.indexOf('TIMEOUT') >= 0
-			)  { resetConnection() }
+			) { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
-				resetConnection()
+				resetConnection(true)
 				return loadPlayPort(options)
 			}
 			throw err
@@ -772,9 +782,9 @@ export namespace Quantel {
 			if (
 				err.message.indexOf('TRANSIENT') >= 0 ||
 				err.message.indexOf('TIMEOUT') >= 0
-			)  { resetConnection() }
+			) { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
-				resetConnection()
+				resetConnection(true)
 				return getPortFragments(options)
 			}
 			throw err
@@ -797,9 +807,9 @@ export namespace Quantel {
 			if (
 				err.message.indexOf('TRANSIENT') >= 0 ||
 				err.message.indexOf('TIMEOUT') >= 0
-			)  { resetConnection() }
+			) { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
-				resetConnection()
+				resetConnection(true)
 				return trigger(options)
 			}
 			throw err
@@ -821,9 +831,9 @@ export namespace Quantel {
 			if (
 				err.message.indexOf('TRANSIENT') >= 0 ||
 				err.message.indexOf('TIMEOUT') >= 0
-			)  { resetConnection() }
+			) { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
-				resetConnection()
+				resetConnection(true)
 				return jump(options)
 			}
 			throw err
@@ -845,9 +855,9 @@ export namespace Quantel {
 			if (
 				err.message.indexOf('TRANSIENT') >= 0 ||
 				err.message.indexOf('TIMEOUT') >= 0
-			)  { resetConnection() }
+			) { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
-				resetConnection()
+				resetConnection(true)
 				return setJump(options)
 			}
 			throw err
@@ -862,9 +872,9 @@ export namespace Quantel {
 			if (
 				err.message.indexOf('TRANSIENT') >= 0 ||
 				err.message.indexOf('TIMEOUT') >= 0
-			)  { resetConnection() }
+			) { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
-				resetConnection()
+				resetConnection(true)
 				return getThumbnailSize()
 			}
 			throw err
@@ -898,9 +908,9 @@ export namespace Quantel {
 			if (
 				err.message.indexOf('TRANSIENT') >= 0 ||
 				err.message.indexOf('TIMEOUT') >= 0
-			)  { resetConnection() }
+			) { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
-				resetConnection()
+				resetConnection(true)
 				return cloneIfNeeded(options)
 			}
 			throw err
@@ -915,9 +925,9 @@ export namespace Quantel {
 			if (
 				err.message.indexOf('TRANSIENT') >= 0 ||
 				err.message.indexOf('TIMEOUT') >= 0
-			)  { resetConnection() }
+			) { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
-				resetConnection()
+				resetConnection(true)
 				return cloneInterZone(options)
 			}
 			throw err
@@ -932,9 +942,9 @@ export namespace Quantel {
 			if (
 				err.message.indexOf('TRANSIENT') >= 0 ||
 				err.message.indexOf('TIMEOUT') >= 0
-			)  { resetConnection() }
+			) { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
-				resetConnection()
+				resetConnection(true)
 				return getCopyRemaining(options)
 			}
 			throw err
@@ -949,9 +959,9 @@ export namespace Quantel {
 			if (
 				err.message.indexOf('TRANSIENT') >= 0 ||
 				err.message.indexOf('TIMEOUT') >= 0
-			)  { resetConnection() }
+			) { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
-				resetConnection()
+				resetConnection(true)
 				return getCopiesRemaining()
 			}
 			throw err
@@ -966,9 +976,9 @@ export namespace Quantel {
 			if (
 				err.message.indexOf('TRANSIENT') >= 0 ||
 				err.message.indexOf('TIMEOUT') >= 0
-			)  { resetConnection() }
+			) { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
-				resetConnection()
+				resetConnection(true)
 				return deleteClip(options)
 			}
 			throw err
@@ -984,9 +994,9 @@ export namespace Quantel {
 			if (
 				err.message.indexOf('TRANSIENT') >= 0 ||
 				err.message.indexOf('TIMEOUT') >= 0
-			)  { resetConnection() }
+			) { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
-				resetConnection()
+				resetConnection(true)
 				return wipe(options)
 			}
 			throw err
@@ -1002,9 +1012,9 @@ export namespace Quantel {
 			if (
 				err.message.indexOf('TRANSIENT') >= 0 ||
 				err.message.indexOf('TIMEOUT') >= 0
-			)  { resetConnection() }
+			) { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
-				resetConnection()
+				resetConnection(true)
 				return wipe(options)
 			}
 			throw err


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Fix

* **What is the current behavior?** (You can also link to an open issue here)

When an ISA Manager is stopped or failed over to the backup, the Quantel Gateway can get into a state where it starts to timeout HTTP requests and does not spot the absense of the ISA. This is until the ISA Manager is restarted, at which point the Quantel Gateway core dumps, forcing the docker container in which it is hosted to restart. 

According to wireshark traces, the CORBA manager clearly sends a "CloseConnection" message but the Quantel Gateway does not act on this.

* **What is the new behavior (if this is a feature change)?**

The Quantel Gateway responds to the CloseConnection message and immediately tries to use the backup, allowing playout control to continue. Unit tests are able to reproduce this and prevent future regressions.

* **Other information**:

The existing unit tests for failover were not sufficient as the test killed the server before it had a chance to send a CloseConnection message..