### PR TITLE
Fix/close connection and failover  

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN yarn install --check-files --frozen-lockfile --production --force # purge de
 FROM node:12-slim
 
 RUN apt-get update && apt-get install -y \
-    libomniorb4-1 \
+    libomniorb4-1 curl \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=0 /opt/quantel-gateway /opt/quantel-gateway

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,7 @@
 module.exports = {
 	globals: {
 		'ts-jest': {
-			tsConfig: 'tsconfig.jest.json',
+			tsconfig: 'tsconfig.jest.json',
 			diagnostics: false
 		}
 	},

--- a/src/__tests__/spawn_server.ts
+++ b/src/__tests__/spawn_server.ts
@@ -75,8 +75,10 @@ export async function start (): Promise<string> {
 export async function stop (): Promise<void> {
 	return new Promise<void>((resolve) => {
 		if (mockServer) {
-			mockServer.kill()
+			console.log('Sending close!')
+			mockServer.send('close')
 			mockServer.on('exit', (_code, _signal) => {
+				console.log('Exiting!')
 				if (app) {
 					app.close(() => {
 						resolve()

--- a/src/__tests__/test_framework.test.ts
+++ b/src/__tests__/test_framework.test.ts
@@ -25,6 +25,12 @@ import { app } from '../server'
 import { Server } from 'http'
 import * as request from 'request-promise-native'
 
+// const wait = (t: number): Promise<void> => { 
+// 	return new Promise((resolve) => {
+// 		setTimeout(resolve, t)
+// 	})
+// }
+
 describe('Test framework', () => {
 
 	let isaIOR: string
@@ -128,7 +134,7 @@ describe('Error handling when no server running', () => {
 
 	test('Test failed IOR HTTP connection', async () => {
 		expect.assertions(1)
-		await expect(Quantel.getServers()).rejects.toThrow('CORBA subsystem: TRANSIENT')
+		await expect(Quantel.getServers()).rejects.toThrow('TIMEOUT')
 	})
 
 	test('Test fail to get servers 1', async () => {
@@ -160,7 +166,12 @@ describe('Error handling when server has failed', () => {
 
 	test('Test fail to get servers 1', async () => {
 		expect.assertions(1)
-		await expect(Quantel.getServers()).rejects.toThrow('CORBA subsystem: TRANSIENT')
+		await expect(Quantel.getServers()).rejects.toThrow('TIMEOUT')
+	})
+
+	test('Test fail to get servers 2', async () => {
+		expect.assertions(1)
+		await expect(Quantel.getServers()).rejects.toThrow('ECONNREFUSED')
 	})
 
 	test('Test the failed CORBA connection', async () => {
@@ -214,7 +225,7 @@ describe('Error handling when server has failed, two servers', () => {
 
 	test('Test fail to get servers 1', async () => {
 		expect.assertions(1)
-		await expect(Quantel.getServers()).rejects.toThrow('CORBA subsystem: TRANSIENT')
+		await expect(Quantel.getServers()).rejects.toThrow('TIMEOUT')
 	})
 
 	test('Test the failed CORBA connection 1', async () => {
@@ -273,8 +284,8 @@ describe('Check overlapping requests on failure', () => {
 	test('Test fail to get servers 1', async () => {
 		expect.assertions(2)
 		await Promise.all([
-			expect(Quantel.getServers()).rejects.toThrow('CORBA subsystem: TRANSIENT'),
-			expect(Quantel.getServers()).rejects.toThrow('CORBA subsystem: TRANSIENT') ])
+			expect(Quantel.getServers()).rejects.toThrow('TIMEOUT'),
+			expect(Quantel.getServers()).rejects.toThrow('TIMEOUT') ])
 	})
 
 	test('Test the failed CORBA connection 1', async () => {

--- a/src/__tests__/test_framework.test.ts
+++ b/src/__tests__/test_framework.test.ts
@@ -25,7 +25,7 @@ import { app } from '../server'
 import { Server } from 'http'
 import * as request from 'request-promise-native'
 
-// const wait = (t: number): Promise<void> => { 
+// const wait = (t: number): Promise<void> => {
 // 	return new Promise((resolve) => {
 // 		setTimeout(resolve, t)
 // 	})

--- a/src/__tests__/test_server.js
+++ b/src/__tests__/test_server.js
@@ -40,11 +40,11 @@ const loopy = setInterval(() => {
 }, 10);
 
 const closeDown = () => {
-	console.error("closeDown called");
+	// console.error("closeDown called");
 	clearInterval(loopy);
-	console.log('quantel.closeServer about to call');
+	// console.log('quantel.closeServer about to call');
 	quantel.closeServer();
-	console.log('quantel.closeServer returned');
+	// console.log('quantel.closeServer returned');
 	// quantel.performWork();
 	// quantel.deactivatePman();
 	setTimeout(() => { process.exit(); }, 3000);
@@ -57,7 +57,7 @@ process.on('message', m => {
 	}
 })
 
-process.on('exit', () => {
-	console.log('BANG!!!')
-})
+// process.on('exit', () => {
+// 	console.log('BANG!!!')
+// })
 

--- a/src/__tests__/test_server.js
+++ b/src/__tests__/test_server.js
@@ -24,4 +24,40 @@ const quantel = require('../../build/Release/quantel_gateway')
 // const SegfaultHandler = require('segfault-handler')
 // SegfaultHandler.registerHandler('crash2.log')
 
+
+
+// process.on('SIGHUP', () => {
+// 	quantel.closeServer()
+// 	console.log("Close server called.")
+// 	setTimeout(() => {}, 3000)
+// })
+
 quantel.runServer()
+
+const loopy = setInterval(() => {
+	// console.log('loopy');
+	quantel.performWork();
+}, 10);
+
+const closeDown = () => {
+	console.error("closeDown called");
+	clearInterval(loopy);
+	console.log('quantel.closeServer about to call');
+	quantel.closeServer();
+	console.log('quantel.closeServer returned');
+	// quantel.performWork();
+	// quantel.deactivatePman();
+	setTimeout(() => { process.exit(); }, 3000);
+}
+
+process.on('SIGINT', closeDown)
+process.on('message', m => {
+	if (typeof m === 'string' && m === 'close') {
+		closeDown();
+	}
+})
+
+process.on('exit', () => {
+	console.log('BANG!!!')
+})
+

--- a/src/cxx/qgw_util.cc
+++ b/src/cxx/qgw_util.cc
@@ -139,6 +139,7 @@ napi_status resolveZonePortal(char* ior, CORBA::ORB_var *orb, Quentin::ZonePorta
 Quentin::ZonePortal_ptr local_zp = nullptr;
 
 napi_status resolveZonePortalShared(char* ior, Quentin::ZonePortal_ptr *zp) {
+	printf("Setting client call timeout period to 2000ms.\n");
 	if (local_orb == nullptr) {
 		const char* options[][2] = { 
 			{ "traceLevel", "1" }, 

--- a/src/cxx/qgw_util.cc
+++ b/src/cxx/qgw_util.cc
@@ -108,7 +108,10 @@ napi_status retrieveZonePortalShared(napi_env env, napi_callback_info info, CORB
   PASS_STATUS;
 
   if (local_orb == nullptr) {
-		const char* options[][2] = { { "traceLevel", "1" }, { 0, 0 } };
+		const char* options[][2] = { 
+			{ "traceLevel", "1" },
+			{ 0, 0 } 
+		};
 		int orbc = 0;
 		local_orb = CORBA::ORB_init(orbc, nullptr, "omniORB4", options);
 	}
@@ -137,7 +140,12 @@ Quentin::ZonePortal_ptr local_zp = nullptr;
 
 napi_status resolveZonePortalShared(char* ior, Quentin::ZonePortal_ptr *zp) {
 	if (local_orb == nullptr) {
-		const char* options[][2] = { { "traceLevel", "21" }, { 0, 0 } };
+		const char* options[][2] = { 
+			{ "traceLevel", "1" }, 
+			{ "clientCallTimeOutPeriod", "2000" },
+			{ "clientConnectTimeOutPeriod", "2000" }, 
+			{ 0, 0 } 
+		};
 	  int orbc = 0;
 	  local_orb = CORBA::ORB_init(orbc, nullptr, "omniORB4", options);
 	}

--- a/src/cxx/qgw_util.cc
+++ b/src/cxx/qgw_util.cc
@@ -147,7 +147,7 @@ napi_status resolveZonePortalShared(char* ior, Quentin::ZonePortal_ptr *zp) {
 
 	if (local_orb == nullptr) {
 		const char* options[][2] = { 
-			{ "traceLevel", "21" }, 
+			{ "traceLevel", "1" }, 
 			{ "clientCallTimeOutPeriod", "2000" },
 			{ "clientConnectTimeOutPeriod", "2000" }, 
 			{ 0, 0 } 

--- a/src/cxx/qgw_util.cc
+++ b/src/cxx/qgw_util.cc
@@ -141,7 +141,7 @@ Quentin::ZonePortal_ptr local_zp = nullptr;
 napi_status resolveZonePortalShared(char* ior, Quentin::ZonePortal_ptr *zp) {
 	if (local_orb == nullptr) {
 		const char* options[][2] = { 
-			{ "traceLevel", "1" }, 
+			{ "traceLevel", "21" }, 
 			{ "clientCallTimeOutPeriod", "2000" },
 			{ "clientConnectTimeOutPeriod", "2000" }, 
 			{ 0, 0 } 

--- a/src/cxx/qgw_util.cc
+++ b/src/cxx/qgw_util.cc
@@ -139,7 +139,6 @@ napi_status resolveZonePortal(char* ior, CORBA::ORB_var *orb, Quentin::ZonePorta
 Quentin::ZonePortal_ptr local_zp = nullptr;
 
 napi_status resolveZonePortalShared(char* ior, Quentin::ZonePortal_ptr *zp) {
-	printf("Setting client call timeout period to 2000ms.\n");
 	if (local_orb == nullptr) {
 		const char* options[][2] = { 
 			{ "traceLevel", "1" }, 

--- a/src/cxx/qgw_util.cc
+++ b/src/cxx/qgw_util.cc
@@ -162,6 +162,14 @@ napi_status resolveZonePortalShared(char* ior, Quentin::ZonePortal_ptr *zp) {
 napi_value destroyOrb(napi_env env, napi_callback_info info) {
 	napi_status status;
 	napi_value result;
+	closedownORB();
+
+	status = napi_get_undefined(env, &result);
+	CHECK_STATUS;
+	return result;
+}
+
+void closedownORB() {
 	if (local_zp != nullptr) {
 		CORBA::release(local_zp);
 	}
@@ -170,10 +178,6 @@ napi_value destroyOrb(napi_env env, napi_callback_info info) {
 	}
 	local_orb = nullptr;
 	local_zp = nullptr;
-
-	status = napi_get_undefined(env, &result);
-	CHECK_STATUS;
-	return result;
 }
 
 std::string formatTimecode(Quentin::Timecode tc) {

--- a/src/cxx/qgw_util.cc
+++ b/src/cxx/qgw_util.cc
@@ -137,7 +137,7 @@ Quentin::ZonePortal_ptr local_zp = nullptr;
 
 napi_status resolveZonePortalShared(char* ior, Quentin::ZonePortal_ptr *zp) {
 	if (local_orb == nullptr) {
-		const char* options[][2] = { { "traceLevel", "1" }, { 0, 0 } };
+		const char* options[][2] = { { "traceLevel", "21" }, { 0, 0 } };
 	  int orbc = 0;
 	  local_orb = CORBA::ORB_init(orbc, nullptr, "omniORB4", options);
 	}

--- a/src/cxx/qgw_util.h
+++ b/src/cxx/qgw_util.h
@@ -174,5 +174,6 @@ napi_status convertToDate(napi_env env, std::string date, napi_value *nodeDate);
 napi_status fragmentsToJS(napi_env env, Quentin::ServerFragments_var fragments, napi_value* prop);
 
 napi_value destroyOrb(napi_env env, napi_callback_info info);
+void closedownORB();
 
 #endif // QGW_UTIL

--- a/src/cxx/qgw_util.h
+++ b/src/cxx/qgw_util.h
@@ -33,6 +33,7 @@
 #include <locale>
 #include <exception>
 #include <inttypes.h>
+#include "omniORB4/minorCode.h"
 #include "node_api.h"
 
 // Now setting from binding.gyp
@@ -175,5 +176,6 @@ napi_status fragmentsToJS(napi_env env, Quentin::ServerFragments_var fragments, 
 
 napi_value destroyOrb(napi_env env, napi_callback_info info);
 void closedownORB();
+void connectionIssue();
 
 #endif // QGW_UTIL

--- a/src/cxx/quantel_gateway.cc
+++ b/src/cxx/quantel_gateway.cc
@@ -78,16 +78,16 @@ napi_value timecodeToBCD(napi_env env, napi_callback_info info) {
 
 CORBA::Boolean commFailureHandler (void* cookie, CORBA::ULong retries, const CORBA::COMM_FAILURE& ex)
 {
-   printf("comm failure handler called.\n");
+   printf("comm failure handler called. Retry %i.\n", (int) retries);
    connectionIssue();
-   return true;
+   return (retries < 10);
 }
 
 CORBA::Boolean transientHandler (void* cookie, CORBA::ULong retries, const CORBA::TRANSIENT& ex)
 {
-   printf("transient failure handler called.\n");
+   printf("transient failure handler called. Retry %i.\n", (int) retries);
    connectionIssue();
-   return true;
+   return (retries < 10);
 }
 
 napi_value Init(napi_env env, napi_value exports) {

--- a/src/cxx/quantel_gateway.cc
+++ b/src/cxx/quantel_gateway.cc
@@ -80,14 +80,14 @@ CORBA::Boolean commFailureHandler (void* cookie, CORBA::ULong retries, const COR
 {
    printf("comm failure handler called.\n");
    connectionIssue();
-   return false;
+   return true;
 }
 
 CORBA::Boolean transientHandler (void* cookie, CORBA::ULong retries, const CORBA::TRANSIENT& ex)
 {
    printf("transient failure handler called.\n");
    connectionIssue();
-   return false;
+   return true;
 }
 
 napi_value Init(napi_env env, napi_value exports) {

--- a/src/cxx/quantel_gateway.cc
+++ b/src/cxx/quantel_gateway.cc
@@ -80,14 +80,14 @@ CORBA::Boolean commFailureHandler (void* cookie, CORBA::ULong retries, const COR
 {
    printf("comm failure handler called. Retry %i.\n", (int) retries);
    connectionIssue();
-   return (retries < 10);
+   return (retries < 5); // Retries used in the case that on failover, the new master is slow to update its IOR
 }
 
 CORBA::Boolean transientHandler (void* cookie, CORBA::ULong retries, const CORBA::TRANSIENT& ex)
 {
    printf("transient failure handler called. Retry %i.\n", (int) retries);
    connectionIssue();
-   return (retries < 10);
+   return (retries < 5); // Retries used in the case that on failover, the new master is slow to update its IOR
 }
 
 napi_value Init(napi_env env, napi_value exports) {

--- a/src/cxx/quantel_gateway.cc
+++ b/src/cxx/quantel_gateway.cc
@@ -27,6 +27,7 @@
 #include "clone.h"
 #include "thumbs.h"
 #include "test_server.h"
+#include <omniORB4/omniORB.h>
 
 napi_value timecodeFromBCD(napi_env env, napi_callback_info info) {
 	napi_status status;
@@ -73,6 +74,12 @@ napi_value timecodeToBCD(napi_env env, napi_callback_info info) {
 	CHECK_STATUS;
 
 	return result;
+}
+
+CORBA::Boolean commFailureHandler (void* cookie, CORBA::ULong retries, const CORBA::COMM_FAILURE& ex)
+{
+   printf("comm failure handler called.\n");
+   return 0;
 }
 
 napi_value Init(napi_env env, napi_value exports) {
@@ -132,6 +139,8 @@ napi_value Init(napi_env env, napi_value exports) {
   };
   status = napi_define_properties(env, exports, 37, desc);
 	CHECK_STATUS;
+
+  omniORB::installCommFailureExceptionHandler(0, commFailureHandler);
 
   return exports;
 }

--- a/src/cxx/quantel_gateway.cc
+++ b/src/cxx/quantel_gateway.cc
@@ -119,6 +119,9 @@ napi_value Init(napi_env env, napi_value exports) {
 		DECLARE_NAPI_METHOD("getCopyRemaining", getCopyRemaining),
 		DECLARE_NAPI_METHOD("getCopiesRemaining", getCopiesRemaining),
 		DECLARE_NAPI_METHOD("runServer", runServer),
+		DECLARE_NAPI_METHOD("closeServer", closeServer),
+		DECLARE_NAPI_METHOD("performWork", performWork),
+		DECLARE_NAPI_METHOD("deactivatePman", deactivatePman), 
 		DECLARE_NAPI_METHOD("destroyOrb", destroyOrb),
     { "START", nullptr, nullptr, nullptr, nullptr, start, napi_enumerable, nullptr },
     { "STOP", nullptr, nullptr, nullptr, nullptr, stop, napi_enumerable, nullptr }, // 30
@@ -127,7 +130,7 @@ napi_value Init(napi_env env, napi_value exports) {
 		{ "STANDARD", nullptr, nullptr, nullptr, nullptr, standard, napi_enumerable, nullptr},
 		{ "HIGH", nullptr, nullptr, nullptr, nullptr, high, napi_enumerable, nullptr},
   };
-  status = napi_define_properties(env, exports, 34, desc);
+  status = napi_define_properties(env, exports, 37, desc);
 	CHECK_STATUS;
 
   return exports;

--- a/src/cxx/quantel_gateway.cc
+++ b/src/cxx/quantel_gateway.cc
@@ -76,11 +76,11 @@ napi_value timecodeToBCD(napi_env env, napi_callback_info info) {
 	return result;
 }
 
-CORBA::Boolean commFailureHandler (void* cookie, CORBA::ULong retries, const CORBA::COMM_FAILURE& ex)
-{
-   printf("comm failure handler called.\n");
-   return 0;
-}
+// CORBA::Boolean commFailureHandler (void* cookie, CORBA::ULong retries, const CORBA::COMM_FAILURE& ex)
+// {
+//    printf("comm failure handler called.\n");
+//    return 0;
+// }
 
 napi_value Init(napi_env env, napi_value exports) {
   napi_status status;
@@ -140,7 +140,7 @@ napi_value Init(napi_env env, napi_value exports) {
   status = napi_define_properties(env, exports, 37, desc);
 	CHECK_STATUS;
 
-  omniORB::installCommFailureExceptionHandler(0, commFailureHandler);
+  // omniORB::installCommFailureExceptionHandler(0, commFailureHandler);
 
   return exports;
 }

--- a/src/cxx/quantel_gateway.cc
+++ b/src/cxx/quantel_gateway.cc
@@ -79,14 +79,14 @@ napi_value timecodeToBCD(napi_env env, napi_callback_info info) {
 CORBA::Boolean commFailureHandler (void* cookie, CORBA::ULong retries, const CORBA::COMM_FAILURE& ex)
 {
    printf("comm failure handler called.\n");
-   closedownORB();
+   connectionIssue();
    return false;
 }
 
 CORBA::Boolean transientHandler (void* cookie, CORBA::ULong retries, const CORBA::TRANSIENT& ex)
 {
    printf("transient failure handler called.\n");
-   closedownORB();
+   connectionIssue();
    return false;
 }
 

--- a/src/cxx/quantel_gateway.cc
+++ b/src/cxx/quantel_gateway.cc
@@ -76,11 +76,12 @@ napi_value timecodeToBCD(napi_env env, napi_callback_info info) {
 	return result;
 }
 
-// CORBA::Boolean commFailureHandler (void* cookie, CORBA::ULong retries, const CORBA::COMM_FAILURE& ex)
-// {
-//    printf("comm failure handler called.\n");
-//    return 0;
-// }
+CORBA::Boolean commFailureHandler (void* cookie, CORBA::ULong retries, const CORBA::COMM_FAILURE& ex)
+{
+   printf("comm failure handler called.\n");
+   closedownORB();
+   return false;
+}
 
 napi_value Init(napi_env env, napi_value exports) {
   napi_status status;
@@ -140,7 +141,7 @@ napi_value Init(napi_env env, napi_value exports) {
   status = napi_define_properties(env, exports, 37, desc);
 	CHECK_STATUS;
 
-  // omniORB::installCommFailureExceptionHandler(0, commFailureHandler);
+  omniORB::installCommFailureExceptionHandler(0, commFailureHandler);
 
   return exports;
 }

--- a/src/cxx/quantel_gateway.cc
+++ b/src/cxx/quantel_gateway.cc
@@ -83,6 +83,13 @@ CORBA::Boolean commFailureHandler (void* cookie, CORBA::ULong retries, const COR
    return false;
 }
 
+CORBA::Boolean transientHandler (void* cookie, CORBA::ULong retries, const CORBA::TRANSIENT& ex)
+{
+   printf("transient failure handler called.\n");
+   closedownORB();
+   return false;
+}
+
 napi_value Init(napi_env env, napi_value exports) {
   napi_status status;
   napi_value start, stop, jump, transition, standard, high;
@@ -142,6 +149,7 @@ napi_value Init(napi_env env, napi_value exports) {
 	CHECK_STATUS;
 
   omniORB::installCommFailureExceptionHandler(0, commFailureHandler);
+  omniORB::installTransientExceptionHandler(0, transientHandler);
 
   return exports;
 }

--- a/src/cxx/test_server.cc
+++ b/src/cxx/test_server.cc
@@ -786,7 +786,7 @@ napi_value runServer(napi_env env, napi_callback_info info) {
 	// napi_status status;
 
 	int argc = 0;
-	const char* options[][2] = { { "traceLevel", "21" }, { 0, 0 } };
+	const char* options[][2] = { { "traceLevel", "1" }, { 0, 0 } };
 	CORBA::ORB_var orb = CORBA::ORB_init(argc, nullptr,"omniORB4",options);
 	myPrettyOrb = orb;
   	CORBA::Object_var obj = orb->resolve_initial_references("RootPOA");
@@ -814,7 +814,7 @@ napi_value runServer(napi_env env, napi_callback_info info) {
 }
 
 napi_value closeServer(napi_env env, napi_callback_info info) {
-	printf("closeServer called.\n");
+	// printf("closeServer called.\n");
 	if (closeMe != nullptr) {
 		myYummyPoa->deactivate_object(myZpId);
 	}

--- a/src/cxx/test_server.h
+++ b/src/cxx/test_server.h
@@ -27,5 +27,8 @@
 #include <wchar.h>
 
 napi_value runServer(napi_env env, napi_callback_info info);
+napi_value closeServer(napi_env env, napi_callback_info info);
+napi_value performWork(napi_env env, napi_callback_info info);
+napi_value deactivatePman(napi_env env, napi_callback_info info);
 
 #endif // QGW_TEST_SERVER

--- a/src/index.ts
+++ b/src/index.ts
@@ -479,8 +479,11 @@ export namespace Quantel {
 			return await quantel.testConnection(await isaIOR)
 		} catch (err) {
 			// if (err.message.indexOf('TRANSIENT') >= 0) { resetConnection() }
-			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0 ||
-					err.message.indexOf('TRANSIENT') >= 0) {
+			if (
+				err.message.indexOf('OBJECT_NOT_EXIST') >= 0 ||
+				err.message.indexOf('TRANSIENT') >= 0 ||
+				err.message.indexOf('TIMEOUT') >= 0
+			) {
 				resetConnection()
 				return testConnection()
 			}
@@ -493,7 +496,10 @@ export namespace Quantel {
 			await getISAReference()
 			return await quantel.listZones(await isaIOR)
 		} catch (err) {
-			if (err.message.indexOf('TRANSIENT') >= 0) { resetConnection() }
+			if (
+				err.message.indexOf('TRANSIENT') >= 0 ||
+				err.message.indexOf('TIMEOUT') >= 0
+			)  { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
 				resetConnection()
 				return listZones()
@@ -508,7 +514,10 @@ export namespace Quantel {
 			let zones = await quantel.listZones(await isaIOR)
 			return zones[0]
 		} catch (err) {
-			if (err.message.indexOf('TRANSIENT') >= 0) { resetConnection() }
+			if (
+				err.message.indexOf('TRANSIENT') >= 0 ||
+				err.message.indexOf('TIMEOUT') >= 0
+			)  { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
 				resetConnection()
 				return getDefaultZoneInfo()
@@ -522,7 +531,10 @@ export namespace Quantel {
 			await getISAReference()
 			return await quantel.getServers(await isaIOR)
 		} catch (err) {
-			if (err.message.indexOf('TRANSIENT') >= 0) { resetConnection() }
+			if (
+				err.message.indexOf('TRANSIENT') >= 0 ||
+				err.message.indexOf('TIMEOUT') >= 0
+			)  { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
 				resetConnection()
 				return getServers()
@@ -536,7 +548,10 @@ export namespace Quantel {
 			await getISAReference()
 			return await quantel.getFormatInfo(await isaIOR, options)
 		} catch (err) {
-			if (err.message.indexOf('TRANSIENT') >= 0) { resetConnection() }
+			if (
+				err.message.indexOf('TRANSIENT') >= 0 ||
+				err.message.indexOf('TIMEOUT') >= 0
+			)  { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
 				resetConnection()
 				return getFormatInfo(options)
@@ -563,7 +578,10 @@ export namespace Quantel {
 			}
 			return formats
 		} catch (err) {
-			if (err.message.indexOf('TRANSIENT') >= 0) { resetConnection() }
+			if (
+				err.message.indexOf('TRANSIENT') >= 0 ||
+				err.message.indexOf('TIMEOUT') >= 0
+			)  { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
 				resetConnection()
 				return getFormats()
@@ -614,7 +632,10 @@ export namespace Quantel {
 
 			return await quantel.createPlayPort(await isaIOR, options)
 		} catch (err) {
-			if (err.message.indexOf('TRANSIENT') >= 0) { resetConnection() }
+			if (
+				err.message.indexOf('TRANSIENT') >= 0 ||
+				err.message.indexOf('TIMEOUT') >= 0
+			)  { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
 				resetConnection()
 				return createPlayPort(options)
@@ -637,7 +658,10 @@ export namespace Quantel {
 			await checkServerPort(options)
 			return await quantel.getPlayPortStatus(await isaIOR, options)
 		} catch (err) {
-			if (err.message.indexOf('TRANSIENT') >= 0) { resetConnection() }
+			if (
+				err.message.indexOf('TRANSIENT') >= 0 ||
+				err.message.indexOf('TIMEOUT') >= 0
+			)  { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
 				resetConnection()
 				return getPlayPortStatus(options)
@@ -652,7 +676,10 @@ export namespace Quantel {
 			await checkServerPort(options)
 			return await quantel.releasePort(await isaIOR, options)
 		} catch (err) {
-			if (err.message.indexOf('TRANSIENT') >= 0) { resetConnection() }
+			if (
+				err.message.indexOf('TRANSIENT') >= 0 ||
+				err.message.indexOf('TIMEOUT') >= 0
+			)  { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
 				resetConnection()
 				return releasePort(options)
@@ -666,7 +693,10 @@ export namespace Quantel {
 			await getISAReference()
 			return await quantel.getClipData(await isaIOR, options)
 		} catch (err) {
-			if (err.message.indexOf('TRANSIENT') >= 0) { resetConnection() }
+			if (
+				err.message.indexOf('TRANSIENT') >= 0 ||
+				err.message.indexOf('TIMEOUT') >= 0
+			)  { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
 				resetConnection()
 				return getClipData(options)
@@ -680,7 +710,10 @@ export namespace Quantel {
 			await getISAReference()
 			return await quantel.searchClips(await isaIOR, options)
 		} catch (err) {
-			if (err.message.indexOf('TRANSIENT') >= 0) { resetConnection() }
+			if (
+				err.message.indexOf('TRANSIENT') >= 0 ||
+				err.message.indexOf('TIMEOUT') >= 0
+			)  { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
 				resetConnection()
 				return searchClips(options)
@@ -697,7 +730,10 @@ export namespace Quantel {
 			}
 			return await quantel.getFragments(await isaIOR, options)
 		} catch (err) {
-			if (err.message.indexOf('TRANSIENT') >= 0) { resetConnection() }
+			if (
+				err.message.indexOf('TRANSIENT') >= 0 ||
+				err.message.indexOf('TIMEOUT') >= 0
+			)  { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
 				resetConnection()
 				return getFragments(options)
@@ -715,7 +751,10 @@ export namespace Quantel {
 			}
 			return await quantel.loadPlayPort(await isaIOR, options)
 		} catch (err) {
-			if (err.message.indexOf('TRANSIENT') >= 0) { resetConnection() }
+			if (
+				err.message.indexOf('TRANSIENT') >= 0 ||
+				err.message.indexOf('TIMEOUT') >= 0
+			)  { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
 				resetConnection()
 				return loadPlayPort(options)
@@ -730,7 +769,10 @@ export namespace Quantel {
 			await checkServerPort(options)
 			return await quantel.getPortFragments(await isaIOR, options)
 		} catch (err) {
-			if (err.message.indexOf('TRANSIENT') >= 0) { resetConnection() }
+			if (
+				err.message.indexOf('TRANSIENT') >= 0 ||
+				err.message.indexOf('TIMEOUT') >= 0
+			)  { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
 				resetConnection()
 				return getPortFragments(options)
@@ -752,7 +794,10 @@ export namespace Quantel {
 				success: await quantel.trigger(await isaIOR, options)
 			}
 		} catch (err) {
-			if (err.message.indexOf('TRANSIENT') >= 0) { resetConnection() }
+			if (
+				err.message.indexOf('TRANSIENT') >= 0 ||
+				err.message.indexOf('TIMEOUT') >= 0
+			)  { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
 				resetConnection()
 				return trigger(options)
@@ -773,7 +818,10 @@ export namespace Quantel {
 				success: await quantel.jump(await isaIOR, options)
 			}
 		} catch (err) {
-			if (err.message.indexOf('TRANSIENT') >= 0) { resetConnection() }
+			if (
+				err.message.indexOf('TRANSIENT') >= 0 ||
+				err.message.indexOf('TIMEOUT') >= 0
+			)  { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
 				resetConnection()
 				return jump(options)
@@ -794,7 +842,10 @@ export namespace Quantel {
 				success: await quantel.setJump(await isaIOR, options)
 			}
 		} catch (err) {
-			if (err.message.indexOf('TRANSIENT') >= 0) { resetConnection() }
+			if (
+				err.message.indexOf('TRANSIENT') >= 0 ||
+				err.message.indexOf('TIMEOUT') >= 0
+			)  { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
 				resetConnection()
 				return setJump(options)
@@ -808,7 +859,10 @@ export namespace Quantel {
 			await getISAReference()
 			return quantel.getThumbnailSize(await isaIOR)
 		} catch (err) {
-			if (err.message.indexOf('TRANSIENT') >= 0) { resetConnection() }
+			if (
+				err.message.indexOf('TRANSIENT') >= 0 ||
+				err.message.indexOf('TIMEOUT') >= 0
+			)  { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
 				resetConnection()
 				return getThumbnailSize()
@@ -841,7 +895,10 @@ export namespace Quantel {
 			await getISAReference()
 			return await quantel.cloneIfNeeded(await isaIOR, options)
 		} catch (err) {
-			if (err.message.indexOf('TRANSIENT') >= 0) { resetConnection() }
+			if (
+				err.message.indexOf('TRANSIENT') >= 0 ||
+				err.message.indexOf('TIMEOUT') >= 0
+			)  { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
 				resetConnection()
 				return cloneIfNeeded(options)
@@ -855,7 +912,10 @@ export namespace Quantel {
 			await getISAReference()
 			return await quantel.cloneInterZone(await isaIOR, options)
 		} catch (err) {
-			if (err.message.indexOf('TRANSIENT') >= 0) { resetConnection() }
+			if (
+				err.message.indexOf('TRANSIENT') >= 0 ||
+				err.message.indexOf('TIMEOUT') >= 0
+			)  { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
 				resetConnection()
 				return cloneInterZone(options)
@@ -869,7 +929,10 @@ export namespace Quantel {
 			await getISAReference()
 			return await quantel.getCopyRemaining(await isaIOR, options)
 		} catch (err) {
-			if (err.message.indexOf('TRANSIENT') >= 0) { resetConnection() }
+			if (
+				err.message.indexOf('TRANSIENT') >= 0 ||
+				err.message.indexOf('TIMEOUT') >= 0
+			)  { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
 				resetConnection()
 				return getCopyRemaining(options)
@@ -883,7 +946,10 @@ export namespace Quantel {
 			await getISAReference()
 			return await quantel.getCopiesRemaining(await isaIOR)
 		} catch (err) {
-			if (err.message.indexOf('TRANSIENT') >= 0) { resetConnection() }
+			if (
+				err.message.indexOf('TRANSIENT') >= 0 ||
+				err.message.indexOf('TIMEOUT') >= 0
+			)  { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
 				resetConnection()
 				return getCopiesRemaining()
@@ -897,7 +963,10 @@ export namespace Quantel {
 			await getISAReference()
 			return await quantel.deleteClip(await isaIOR, options)
 		} catch (err) {
-			if (err.message.indexOf('TRANSIENT') >= 0) { resetConnection() }
+			if (
+				err.message.indexOf('TRANSIENT') >= 0 ||
+				err.message.indexOf('TIMEOUT') >= 0
+			)  { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
 				resetConnection()
 				return deleteClip(options)
@@ -912,7 +981,10 @@ export namespace Quantel {
 			await checkServerPort(options)
 			return await quantel.wipe(await isaIOR, options)
 		} catch (err) {
-			if (err.message.indexOf('TRANSIENT') >= 0) { resetConnection() }
+			if (
+				err.message.indexOf('TRANSIENT') >= 0 ||
+				err.message.indexOf('TIMEOUT') >= 0
+			)  { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
 				resetConnection()
 				return wipe(options)
@@ -927,7 +999,10 @@ export namespace Quantel {
 			await checkServerPort(options)
 			return await quantel.getPortProperties(await isaIOR, options)
 		} catch (err) {
-			if (err.message.indexOf('TRANSIENT') >= 0) { resetConnection() }
+			if (
+				err.message.indexOf('TRANSIENT') >= 0 ||
+				err.message.indexOf('TIMEOUT') >= 0
+			)  { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
 				resetConnection()
 				return wipe(options)

--- a/src/index.ts
+++ b/src/index.ts
@@ -436,7 +436,8 @@ export namespace Quantel {
 			if (stickyRef[index].indexOf(':') < 0) { stickyRef[index] = stickyRef[index] + ':2096' }
 			request({
 				uri: stickyRef[index] + '/ZoneManager.ior',
-				resolveWithFullResponse: true
+				resolveWithFullResponse: true,
+				timeout: 1000
 			}).then(res => {
 				if (res.statusCode === 200) {
 					resolve(res.body)

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,7 @@ export namespace Quantel {
 	let stickyRef: string[] = [ 'http://localhost:2096' ]
 	let robin = 0
 	let connectAttempt = false
+	let objectNotFoundCount = 0
 
 	export interface ZoneInfo {
 		type: 'ZonePortal'
@@ -405,7 +406,12 @@ export namespace Quantel {
 		quantel.destroyOrb()
 	}
 
-	function resetConnection () {
+	function resetConnection (objectNotFound?: boolean) {
+		if (objectNotFound) {
+			objectNotFoundCount++
+		} else {
+			objectNotFoundCount = 0
+		}
 		isaIOR = null
 		robin++
 	}
@@ -415,6 +421,10 @@ export namespace Quantel {
 			throw new ConnectError(`First provide a Quantel ISA connection URL (e.g. POST to /connect).`, 502)
 		} else {
 			connectAttempt = true
+		}
+		if (objectNotFoundCount > 5) {
+			resetConnection(false)
+			throw new ConnectError(`Five OBJECT_NOT_EXIST exceptions in a row. Preventing loop. System in a bad state.`)
 		}
 		if (typeof ref === 'string') ref = [ ref ]
 		let myCount: number = count ? count + 1 : 1
@@ -484,7 +494,7 @@ export namespace Quantel {
 				err.message.indexOf('TRANSIENT') >= 0 ||
 				err.message.indexOf('TIMEOUT') >= 0
 			) {
-				resetConnection()
+				resetConnection(true)
 				return testConnection()
 			}
 			throw err
@@ -499,9 +509,9 @@ export namespace Quantel {
 			if (
 				err.message.indexOf('TRANSIENT') >= 0 ||
 				err.message.indexOf('TIMEOUT') >= 0
-			)  { resetConnection() }
+			) { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
-				resetConnection()
+				resetConnection(true)
 				return listZones()
 			}
 			throw err
@@ -517,9 +527,9 @@ export namespace Quantel {
 			if (
 				err.message.indexOf('TRANSIENT') >= 0 ||
 				err.message.indexOf('TIMEOUT') >= 0
-			)  { resetConnection() }
+			) { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
-				resetConnection()
+				resetConnection(true)
 				return getDefaultZoneInfo()
 			}
 			throw err
@@ -534,9 +544,9 @@ export namespace Quantel {
 			if (
 				err.message.indexOf('TRANSIENT') >= 0 ||
 				err.message.indexOf('TIMEOUT') >= 0
-			)  { resetConnection() }
+			) { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
-				resetConnection()
+				resetConnection(true)
 				return getServers()
 			}
 			throw err
@@ -551,9 +561,9 @@ export namespace Quantel {
 			if (
 				err.message.indexOf('TRANSIENT') >= 0 ||
 				err.message.indexOf('TIMEOUT') >= 0
-			)  { resetConnection() }
+			) { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
-				resetConnection()
+				resetConnection(true)
 				return getFormatInfo(options)
 			}
 			throw err
@@ -581,9 +591,9 @@ export namespace Quantel {
 			if (
 				err.message.indexOf('TRANSIENT') >= 0 ||
 				err.message.indexOf('TIMEOUT') >= 0
-			)  { resetConnection() }
+			) { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
-				resetConnection()
+				resetConnection(true)
 				return getFormats()
 			}
 			throw err
@@ -635,9 +645,9 @@ export namespace Quantel {
 			if (
 				err.message.indexOf('TRANSIENT') >= 0 ||
 				err.message.indexOf('TIMEOUT') >= 0
-			)  { resetConnection() }
+			) { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
-				resetConnection()
+				resetConnection(true)
 				return createPlayPort(options)
 			}
 			throw err
@@ -661,9 +671,9 @@ export namespace Quantel {
 			if (
 				err.message.indexOf('TRANSIENT') >= 0 ||
 				err.message.indexOf('TIMEOUT') >= 0
-			)  { resetConnection() }
+			) { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
-				resetConnection()
+				resetConnection(true)
 				return getPlayPortStatus(options)
 			}
 			throw err
@@ -679,9 +689,9 @@ export namespace Quantel {
 			if (
 				err.message.indexOf('TRANSIENT') >= 0 ||
 				err.message.indexOf('TIMEOUT') >= 0
-			)  { resetConnection() }
+			) { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
-				resetConnection()
+				resetConnection(true)
 				return releasePort(options)
 			}
 			throw err
@@ -696,9 +706,9 @@ export namespace Quantel {
 			if (
 				err.message.indexOf('TRANSIENT') >= 0 ||
 				err.message.indexOf('TIMEOUT') >= 0
-			)  { resetConnection() }
+			) { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
-				resetConnection()
+				resetConnection(true)
 				return getClipData(options)
 			}
 			throw err
@@ -713,9 +723,9 @@ export namespace Quantel {
 			if (
 				err.message.indexOf('TRANSIENT') >= 0 ||
 				err.message.indexOf('TIMEOUT') >= 0
-			)  { resetConnection() }
+			) { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
-				resetConnection()
+				resetConnection(true)
 				return searchClips(options)
 			}
 			throw err
@@ -733,9 +743,9 @@ export namespace Quantel {
 			if (
 				err.message.indexOf('TRANSIENT') >= 0 ||
 				err.message.indexOf('TIMEOUT') >= 0
-			)  { resetConnection() }
+			) { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
-				resetConnection()
+				resetConnection(true)
 				return getFragments(options)
 			}
 			throw err
@@ -754,9 +764,9 @@ export namespace Quantel {
 			if (
 				err.message.indexOf('TRANSIENT') >= 0 ||
 				err.message.indexOf('TIMEOUT') >= 0
-			)  { resetConnection() }
+			) { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
-				resetConnection()
+				resetConnection(true)
 				return loadPlayPort(options)
 			}
 			throw err
@@ -772,9 +782,9 @@ export namespace Quantel {
 			if (
 				err.message.indexOf('TRANSIENT') >= 0 ||
 				err.message.indexOf('TIMEOUT') >= 0
-			)  { resetConnection() }
+			) { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
-				resetConnection()
+				resetConnection(true)
 				return getPortFragments(options)
 			}
 			throw err
@@ -797,9 +807,9 @@ export namespace Quantel {
 			if (
 				err.message.indexOf('TRANSIENT') >= 0 ||
 				err.message.indexOf('TIMEOUT') >= 0
-			)  { resetConnection() }
+			) { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
-				resetConnection()
+				resetConnection(true)
 				return trigger(options)
 			}
 			throw err
@@ -821,9 +831,9 @@ export namespace Quantel {
 			if (
 				err.message.indexOf('TRANSIENT') >= 0 ||
 				err.message.indexOf('TIMEOUT') >= 0
-			)  { resetConnection() }
+			) { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
-				resetConnection()
+				resetConnection(true)
 				return jump(options)
 			}
 			throw err
@@ -845,9 +855,9 @@ export namespace Quantel {
 			if (
 				err.message.indexOf('TRANSIENT') >= 0 ||
 				err.message.indexOf('TIMEOUT') >= 0
-			)  { resetConnection() }
+			) { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
-				resetConnection()
+				resetConnection(true)
 				return setJump(options)
 			}
 			throw err
@@ -862,9 +872,9 @@ export namespace Quantel {
 			if (
 				err.message.indexOf('TRANSIENT') >= 0 ||
 				err.message.indexOf('TIMEOUT') >= 0
-			)  { resetConnection() }
+			) { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
-				resetConnection()
+				resetConnection(true)
 				return getThumbnailSize()
 			}
 			throw err
@@ -898,9 +908,9 @@ export namespace Quantel {
 			if (
 				err.message.indexOf('TRANSIENT') >= 0 ||
 				err.message.indexOf('TIMEOUT') >= 0
-			)  { resetConnection() }
+			) { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
-				resetConnection()
+				resetConnection(true)
 				return cloneIfNeeded(options)
 			}
 			throw err
@@ -915,9 +925,9 @@ export namespace Quantel {
 			if (
 				err.message.indexOf('TRANSIENT') >= 0 ||
 				err.message.indexOf('TIMEOUT') >= 0
-			)  { resetConnection() }
+			) { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
-				resetConnection()
+				resetConnection(true)
 				return cloneInterZone(options)
 			}
 			throw err
@@ -932,9 +942,9 @@ export namespace Quantel {
 			if (
 				err.message.indexOf('TRANSIENT') >= 0 ||
 				err.message.indexOf('TIMEOUT') >= 0
-			)  { resetConnection() }
+			) { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
-				resetConnection()
+				resetConnection(true)
 				return getCopyRemaining(options)
 			}
 			throw err
@@ -949,9 +959,9 @@ export namespace Quantel {
 			if (
 				err.message.indexOf('TRANSIENT') >= 0 ||
 				err.message.indexOf('TIMEOUT') >= 0
-			)  { resetConnection() }
+			) { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
-				resetConnection()
+				resetConnection(true)
 				return getCopiesRemaining()
 			}
 			throw err
@@ -966,9 +976,9 @@ export namespace Quantel {
 			if (
 				err.message.indexOf('TRANSIENT') >= 0 ||
 				err.message.indexOf('TIMEOUT') >= 0
-			)  { resetConnection() }
+			) { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
-				resetConnection()
+				resetConnection(true)
 				return deleteClip(options)
 			}
 			throw err
@@ -984,9 +994,9 @@ export namespace Quantel {
 			if (
 				err.message.indexOf('TRANSIENT') >= 0 ||
 				err.message.indexOf('TIMEOUT') >= 0
-			)  { resetConnection() }
+			) { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
-				resetConnection()
+				resetConnection(true)
 				return wipe(options)
 			}
 			throw err
@@ -1002,9 +1012,9 @@ export namespace Quantel {
 			if (
 				err.message.indexOf('TRANSIENT') >= 0 ||
 				err.message.indexOf('TIMEOUT') >= 0
-			)  { resetConnection() }
+			) { resetConnection() }
 			if (err.message.indexOf('OBJECT_NOT_EXIST') >= 0) {
-				resetConnection()
+				resetConnection(true)
 				return wipe(options)
 			}
 			throw err

--- a/src/server.ts
+++ b/src/server.ts
@@ -38,7 +38,7 @@ function errorLog (...args: any[]) {
 	console.error(...args)
 }
 
-infoLog('Starting Quantel Gateway')
+infoLog('Starting Quantel Gateway - TIMEOUT test version')
 infoLog(`Sofie: Quantel gateway  Copyright (c) 2019 Norsk rikskringkasting AS (NRK)
 
 Sofie: Quantel gateway comes with ABSOLUTELY NO WARRANTY.

--- a/src/server.ts
+++ b/src/server.ts
@@ -585,7 +585,7 @@ router.get('/default/clip/:clipID/fragments/:in-:out', async (ctx) => {
 		ctx.status = 400
 		ctx.body = {
 			status: 400,
-			message: 'Bad request. Out point must be after in point.',
+			message: `Bad request. Out point "${ctx.params.out}" must be after in point "${ctx.params.in}".`,
 			stack: ''
 		} as JSONError
 		return


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Fix

* **What is the current behavior?** (You can also link to an open issue here)

Failover of the ISA Managers can cause the quantel gateway to freeze (actually in a continuous reconnect loop at the CORBA layer).

* **What is the new behavior (if this is a feature change)?**

Closing connections to the ISA cause the gateway to crash (not ideal ... but good enough) and the gateway to restart. Also handles a race condition where the ISA manager promoted to master can point to its predecessor for a short while after starting.

* **Other information**:
